### PR TITLE
Updates cloudbuild.yaml and hugo version from 0.115.0 to 0.115.2 #31

### DIFF
--- a/cloudbuild-prod.yaml
+++ b/cloudbuild-prod.yaml
@@ -16,7 +16,7 @@ steps:
       - "hugo.tar.gz"
       - "https://github.com/gohugoio/hugo/releases/download/v${_HUGO_VERSION}/hugo_extended_${_HUGO_VERSION}_Linux-64bit.tar.gz"
     waitFor: ["-"]
-  - name: "golang:1-bullseye"
+  - name: "golang:1"
     env:
     - "PROJECT_ID=$PROJECT_ID"
     - "BUILD_ID=$BUILD_ID"
@@ -41,5 +41,5 @@ steps:
       mv functions/web/* public/
       /tmp/firebase --project ${PROJECT_ID} --non-interactive deploy --only hosting -m "Build ${BUILD_ID}"
 substitutions:
-  _HUGO_VERSION: 0.115.0
+  _HUGO_VERSION: 0.115.2
   _HUGO_ENV: production

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,7 +16,7 @@ steps:
       - "hugo.tar.gz"
       - "https://github.com/gohugoio/hugo/releases/download/v${_HUGO_VERSION}/hugo_extended_${_HUGO_VERSION}_Linux-64bit.tar.gz"
     waitFor: ["-"]
-  - name: "golang:1-bullseye"
+  - name: "golang:1"
     env:
     - "PROJECT_ID=$PROJECT_ID"
     - "BUILD_ID=$BUILD_ID"
@@ -42,5 +42,5 @@ steps:
       cd /workspace/
       /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy ${PREVIEW_CHANNEL_NAME} --expires ${EXPIRE_TIME}
 substitutions:
-  _HUGO_VERSION: 0.115.0
+  _HUGO_VERSION: 0.115.2
   _HUGO_ENV: development


### PR DESCRIPTION
- hugo version を 0.115.0 から 0.115.2 に更新
- goのコンテナイメージについて、ベースOSを指定せず常に最新のメジャーバージョンを使うように変更