### PR TITLE
Revert "[production <- staging] #45"

### DIFF
--- a/hugo/layouts/partials/head-additions.html
+++ b/hugo/layouts/partials/head-additions.html
@@ -1,1 +1,0 @@
-{{ template "_internal/google_analytics.html" . }}


### PR DESCRIPTION
websiteのHeaderが以下のように、二重でGA4が実行されるためコミットを取り消す

```
<script async="" src="https://www.googletagmanager.com/gtag/js?id=G-16VJ0X1ZQ7"></script>
<script>
    var doNotTrack = false;
    if (!doNotTrack) {
        window.dataLayer = window.dataLayer || [];
        function gtag(){dataLayer.push(arguments);}
        gtag('js', new Date());
        gtag('config', 'G-16VJ0X1ZQ7', { 'anonymize_ip': false });
    }
    </script>
<script async="" src="https://www.googletagmanager.com/gtag/js?id=G-16VJ0X1ZQ7"></script>
<script>
    var doNotTrack = false;
    if (!doNotTrack) {
        window.dataLayer = window.dataLayer || [];
        function gtag(){dataLayer.push(arguments);}
        gtag('js', new Date());
        gtag('config', 'G-16VJ0X1ZQ7', { 'anonymize_ip': false });
    }
    </script>
```