### PR TITLE
Update cloudbuild.yaml & hugo.toml & config.toml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,7 +20,7 @@ steps:
     env:
     - "PROJECT_ID=$PROJECT_ID"
     - "BUILD_ID=$BUILD_ID"
-    - "RELEASE_CHANNEL_NAME=$_RELEASE_CHANNEL_NAME"
+    - "RELEASE_CHANNEL=$_RELEASE_CHANNEL"
     - "EXPIRE_TIME=$_EXPIRE_TIME"
     script: |
       #!/usr/bin/env bash
@@ -38,14 +38,15 @@ steps:
       fi
 
       cd /workspace/hugo
-      if [[ "${RELEASE_CHANNEL_NAME}" == "production" ]]; then
-        /tmp/hugo --environment production --minify
+      if [[ "${RELEASE_CHANNEL}" == "production" ]]; then
+        HUGO_ENV="production" \
+        /tmp/hugo --cleanDestinationDir --gc --minify --environment production
         cd /workspace/
         /tmp/firebase --project ${PROJECT_ID} --non-interactive deploy --only hosting -m "Build ${BUILD_ID}"
       else
-        /tmp/hugo --environment development --minify --buildFuture
+        /tmp/hugo --cleanDestinationDir --gc --minify --environment development --buildFuture 
         cd /workspace/
-        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy ${RELEASE_CHANNEL_NAME} --expires ${EXPIRE_TIME}
+        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy ${PREVIEW_CHANNEL_NAME} --expires ${EXPIRE_TIME}
       fi
 substitutions:
   _HUGO_VERSION: 0.121.1

--- a/hugo/config/_default/hugo.toml
+++ b/hugo/config/_default/hugo.toml
@@ -5,12 +5,15 @@ DefaultContentLanguage = "ja"
 languageCode           = "ja"
 Paginate               = 10
 timeZone               = "Asia/Tokyo"
-googleAnalytics        = ""
 enableRobotsTXT        = false
 publishDir             = "../public"
 contentDir             = "content/ja"
 title                  = "IAESTE Japan"
 theme                  = ["github.com/theNewDynamic/gohugo-theme-ananke"]
+
+[services]
+  [services.googleAnalytics]
+    ID = ""
 
 [markup]
   [markup.goldmark]

--- a/hugo/config/production/config.toml
+++ b/hugo/config/production/config.toml
@@ -1,2 +1,4 @@
-googleAnalytics = "G-16VJ0X1ZQ7"
 enableRobotsTXT = true
+[services]
+  [services.googleAnalytics]
+    ID = "G-16VJ0X1ZQ7"


### PR DESCRIPTION
- `site.GoogleAnalytics` の廃止に対応
  - https://github.com/gohugoio/hugo/releases/tag/v0.120.0
- e35c3c71781446a31d9b58358c11858fe6a80965 で消してしまった `HUGO_ENV` を復活
  - `hugo --environment production` のみでは gohugo-theme-ananke の本番環境機能が動かないため
    - https://github.com/theNewDynamic/gohugo-theme-ananke?tab=readme-ov-file#production