### PR TITLE
Update firebase.json and cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -43,6 +43,7 @@ steps:
         CHANNEL_URL=$(/tmp/firebase --project ${PROJECT_ID} hosting:channel:open ${_CHANNEL_ID} | grep "https://" | awk '{print $3}')
         /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL ${CHANNEL_URL}/ --buildFuture 
         cd /workspace/
+        echo "/tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy ${_CHANNEL_ID} --expires ${_EXPIRE_TIME}"
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy ${_CHANNEL_ID} --expires ${_EXPIRE_TIME}
       fi
 substitutions:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,18 +33,18 @@ steps:
       fi
 
       cd /workspace/hugo
-      if [[ "${_CHANNEL_ID}" == "production" ]]; then
+      if [[ "$_CHANNEL_ID" == "production" ]]; then
         HUGO_ENV="production" \
         /tmp/hugo --cleanDestinationDir --gc --minify --environment production
         cd /workspace/
         /tmp/firebase --project ${PROJECT_ID} --non-interactive deploy --only hosting -m "Build ${BUILD_ID}"
       else
-        /tmp/firebase --project ${PROJECT_ID} hosting:channel:create ${_CHANNEL_ID}
-        CHANNEL_URL=$(/tmp/firebase --project ${PROJECT_ID} hosting:channel:open ${_CHANNEL_ID} | grep "https://" | awk '{print $3}')
-        /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL ${CHANNEL_URL}/ --buildFuture 
+        /tmp/firebase --project ${PROJECT_ID} hosting:channel:create $_CHANNEL_ID
+        CHANNEL_URL=$(/tmp/firebase --project ${PROJECT_ID} hosting:channel:open $_CHANNEL_ID | grep "https://" | awk '{print $3}')
+        /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL $CHANNEL_URL/ --buildFuture 
         cd /workspace/
-        echo "/tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy ${_CHANNEL_ID} --expires ${_EXPIRE_TIME}"
-        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy ${_CHANNEL_ID} --expires ${_EXPIRE_TIME}
+        echo "/tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy $_CHANNEL_ID --expires $_EXPIRE_TIME"
+        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy $_CHANNEL_ID --expires $_EXPIRE_TIME
       fi
 substitutions:
   _HUGO_VERSION: 0.121.1

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
       - "https://github.com/gohugoio/hugo/releases/download/v${_HUGO_VERSION}/hugo_extended_${_HUGO_VERSION}_Linux-64bit.tar.gz"
     waitFor: ["-"]
   - name: "golang:1"
-      env:
+    env:
     - "PROJECT_ID=$PROJECT_ID"
     - "BUILD_ID=$BUILD_ID"
     - "_CHANNEL_ID=$_CHANNEL_ID"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -47,4 +47,3 @@ steps:
       fi
 substitutions:
   _HUGO_VERSION: 0.121.1
-  _EXPIRE_TIME: 3h

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,6 +17,11 @@ steps:
       - "https://github.com/gohugoio/hugo/releases/download/v${_HUGO_VERSION}/hugo_extended_${_HUGO_VERSION}_Linux-64bit.tar.gz"
     waitFor: ["-"]
   - name: "golang:1"
+      env:
+    - "PROJECT_ID=$PROJECT_ID"
+    - "BUILD_ID=$BUILD_ID"
+    - "_CHANNEL_ID=$_CHANNEL_ID"
+    - "_EXPIRE_TIME=$_EXPIRE_TIME"
     script: |
       #!/usr/bin/env bash
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,11 +17,6 @@ steps:
       - "https://github.com/gohugoio/hugo/releases/download/v${_HUGO_VERSION}/hugo_extended_${_HUGO_VERSION}_Linux-64bit.tar.gz"
     waitFor: ["-"]
   - name: "golang:1"
-    env:
-    - "PROJECT_ID=$PROJECT_ID"
-    - "BUILD_ID=$BUILD_ID"
-    - "RELEASE_CHANNEL=$_RELEASE_CHANNEL"
-    - "EXPIRE_TIME=$_EXPIRE_TIME"
     script: |
       #!/usr/bin/env bash
 
@@ -38,15 +33,18 @@ steps:
       fi
 
       cd /workspace/hugo
-      if [[ "${RELEASE_CHANNEL}" == "production" ]]; then
+      if [[ "${CHANNEL_ID}" == "production" ]]; then
         HUGO_ENV="production" \
         /tmp/hugo --cleanDestinationDir --gc --minify --environment production
         cd /workspace/
         /tmp/firebase --project ${PROJECT_ID} --non-interactive deploy --only hosting -m "Build ${BUILD_ID}"
       else
-        /tmp/hugo --cleanDestinationDir --gc --minify --environment development --buildFuture 
+        /tmp/firebase --project ${PROJECT_ID} hosting:channel:create ${CHANNEL_ID}
+        CHANNEL_URL=$(firebase --project ${PROJECT_ID} hosting:channel:open ${CHANNEL_ID} | grep "https://" | awk '{print $3}')
+        /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL ${CHANNEL_URL}/ --buildFuture 
         cd /workspace/
-        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy ${RELEASE_CHANNEL} --expires ${EXPIRE_TIME}
+        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy ${CHANNEL_ID} --expires ${EXPIRE_TIME}
       fi
 substitutions:
   _HUGO_VERSION: 0.121.1
+  _EXPIRE_TIME: 3h

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -40,7 +40,7 @@ steps:
         /tmp/firebase --project ${PROJECT_ID} --non-interactive deploy --only hosting -m "Build ${BUILD_ID}"
       else
         /tmp/firebase --project ${PROJECT_ID} hosting:channel:create ${_CHANNEL_ID}
-        CHANNEL_URL=$(firebase --project ${PROJECT_ID} hosting:channel:open ${_CHANNEL_ID} | grep "https://" | awk '{print $3}')
+        CHANNEL_URL=$(/tmp/firebase --project ${PROJECT_ID} hosting:channel:open ${_CHANNEL_ID} | grep "https://" | awk '{print $3}')
         /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL ${CHANNEL_URL}/ --buildFuture 
         cd /workspace/
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy ${_CHANNEL_ID} --expires ${_EXPIRE_TIME}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,17 +33,17 @@ steps:
       fi
 
       cd /workspace/hugo
-      if [[ "${CHANNEL_ID}" == "production" ]]; then
+      if [[ "${_CHANNEL_ID}" == "production" ]]; then
         HUGO_ENV="production" \
         /tmp/hugo --cleanDestinationDir --gc --minify --environment production
         cd /workspace/
         /tmp/firebase --project ${PROJECT_ID} --non-interactive deploy --only hosting -m "Build ${BUILD_ID}"
       else
-        /tmp/firebase --project ${PROJECT_ID} hosting:channel:create ${CHANNEL_ID}
-        CHANNEL_URL=$(firebase --project ${PROJECT_ID} hosting:channel:open ${CHANNEL_ID} | grep "https://" | awk '{print $3}')
+        /tmp/firebase --project ${PROJECT_ID} hosting:channel:create ${_CHANNEL_ID}
+        CHANNEL_URL=$(firebase --project ${PROJECT_ID} hosting:channel:open ${_CHANNEL_ID} | grep "https://" | awk '{print $3}')
         /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL ${CHANNEL_URL}/ --buildFuture 
         cd /workspace/
-        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy ${CHANNEL_ID} --expires ${EXPIRE_TIME}
+        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy ${_CHANNEL_ID} --expires ${_EXPIRE_TIME}
       fi
 substitutions:
   _HUGO_VERSION: 0.121.1

--- a/firebase.json
+++ b/firebase.json
@@ -11,7 +11,7 @@
       "headers": [
         {
           "key" : "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://*.googletagmanager.com; img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; style-src 'self'"
+          "value": "default-src 'self'; script-src 'self' https://*.googletagmanager.com; img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; style-src 'self' 'unsafe-inline';"
         },
         {
           "key" : "Strict-Transport-Security",

--- a/firebase.json
+++ b/firebase.json
@@ -11,7 +11,7 @@
       "headers": [
         {
           "key" : "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://*.googletagmanager.com; img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com"
+          "value": "default-src 'self'; script-src 'self' https://*.googletagmanager.com; img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; style-src 'self'"
         },
         {
           "key" : "Strict-Transport-Security",


### PR DESCRIPTION
e89106a64308794aebcc67d3f35fec42d0ceb5d5 で追加した Content-Security-Policy の修正

firebase.json
- Markdown ファイル内のスタイルシートを許可するように Content-Security-Policy のkey を修正

cloudbuild.yaml
- hugo を build する際、 baseURL がテスト環境になるように修正 (修正前は iaeste.or.jp に固定されていた)
  1. firebase hosting の channel を作成
  2. 作成した channel の URL を取得
  3. 取得した URL を baseURL に指定して hugo build を実施
  4. firebase hosting の channel に hugo build したファイルをアップロード
- 変数名 RELEASE_CHANNEL を _CHANNEL_ID に変更
- 変数名 EXPIRE_TIME を _EXPIRE_TIME に変更