### PR TITLE
Update cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -48,7 +48,7 @@ steps:
         CHANNEL_URL=$(/tmp/firebase --project ${PROJECT_ID} hosting:channel:open $_CHANNEL_ID | grep "https://" | awk '{print $3}')
         /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL $CHANNEL_URL/ --buildFuture 
         cd /workspace/
-        echo "/tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy $_CHANNEL_ID --expires $_EXPIRE_TIME"
+        echo "CHANNEL_URL = $CHANNEL_URL"
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy $_CHANNEL_ID --expires $_EXPIRE_TIME
       fi
 substitutions:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -45,10 +45,10 @@ steps:
         /tmp/firebase --project ${PROJECT_ID} --non-interactive deploy --only hosting -m "Build ${BUILD_ID}"
       else
         /tmp/firebase --project ${PROJECT_ID} hosting:channel:create $_CHANNEL_ID
-        CHANNEL_URL=$(/tmp/firebase --project ${PROJECT_ID} hosting:channel:open $_CHANNEL_ID | grep "https://" | awk '{print $3}')
-        /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL $CHANNEL_URL/ --buildFuture 
+        _CHANNEL_URL=$(/tmp/firebase --project ${PROJECT_ID} hosting:channel:open $_CHANNEL_ID | grep "https://" | awk '{print $3}')
+        echo "_CHANNEL_URL = $_CHANNEL_URL"
+        /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL $_CHANNEL_URL/ --buildFuture 
         cd /workspace/
-        echo "CHANNEL_URL = $CHANNEL_URL"
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy $_CHANNEL_ID --expires $_EXPIRE_TIME
       fi
 substitutions:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,4 +52,4 @@ steps:
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy $_CHANNEL_ID --expires $_EXPIRE_TIME
       fi
 substitutions:
-  _HUGO_VERSION: 0.121.1
+  _HUGO_VERSION: 0.122.0


### PR DESCRIPTION
- gohugo version を 0.121.1 から 0.122.0 に更新
- 変数名 CHANNEL_URL を _CHANNEL_URL に変更
  - ユーザ変数は _ から始まる住み分けをしているので、ルールに合わせた
- production branch 以外の build 時に、デバッグ目的で _CHANNEL_URL の値を echo で出力するように変更