### PR TITLE
Update hugo.toml

### DIFF
--- a/hugo/config/_default/hugo.toml
+++ b/hugo/config/_default/hugo.toml
@@ -3,9 +3,10 @@
 baseURL                = "https://www.iaeste.or.jp/"
 DefaultContentLanguage = "ja"
 languageCode           = "ja"
-Paginate               = 10
+Paginate               = 9
 timeZone               = "Asia/Tokyo"
 enableRobotsTXT        = false
+hasCJKLanguage         = true
 publishDir             = "../public"
 contentDir             = "content/ja"
 title                  = "IAESTE Japan"


### PR DESCRIPTION
Paginate
- news の並びが横3記事分なので、10から9に変更

hasCJKLanguage
- news ページなどで記事の見出し (サマリー) が長くならないように調整する
- 明示的に宣言しなければ中国語、日本語、韓国語はサマリーが長くなる仕様のため