### PR TITLE
Modify Content-Security-Policy value

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -16,11 +16,7 @@
           },
           {
             "key": "Content-Security-Policy",
-            "value": "frame-ancestors 'none';"
-          },
-          {
-            "key": "Content-Security-Policy",
-            "value": "default-src 'self'; script-src 'self' https://*.googletagmanager.com 'sha256-dkOtSzvFrLxTqUWJ56gAiNHAPClZnm8nRrXm5szMZVw='; img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; style-src 'self' 'unsafe-inline'; object-src 'none';"
+            "value": "default-src 'none'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; script-src 'self' https://*.googletagmanager.com 'sha256-dkOtSzvFrLxTqUWJ56gAiNHAPClZnm8nRrXm5szMZVw='; img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; style-src 'self' 'unsafe-inline'; form-action 'self'; form-action 'self';"
           },
           {
             "key": "X-Frame-Options",

--- a/firebase.json
+++ b/firebase.json
@@ -16,7 +16,7 @@
           },
           {
             "key": "Content-Security-Policy",
-            "value": "default-src 'none'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; script-src 'self' https://*.googletagmanager.com 'sha256-dkOtSzvFrLxTqUWJ56gAiNHAPClZnm8nRrXm5szMZVw='; img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; style-src 'self' 'unsafe-inline'; form-action 'self'; form-action 'self';"
+            "value": "default-src 'none'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; script-src 'self' https://*.googletagmanager.com 'sha256-dkOtSzvFrLxTqUWJ56gAiNHAPClZnm8nRrXm5szMZVw='; img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; style-src 'self' 'unsafe-inline'; form-action 'self';"
           },
           {
             "key": "X-Frame-Options",


### PR DESCRIPTION
1. [Mozilla Observatory :: Scan Results for www.iaeste.or.jp](https://observatory.mozilla.org/analyze/www.iaeste.or.jp) に従い、以下の値を追加
    - default-src 'none'
    - object-src 'none'
    - base-uri 'self'
    - form-action 'self'
2. Content-Security-Policy を複数行にすると正常に読み込まれなかったので、1行にまとめた
    - frame-ancestors 'none'