### PR TITLE
TLSC のドメイン更新に伴う表記修正

### DIFF
--- a/hugo/content/en/contact.md
+++ b/hugo/content/en/contact.md
@@ -21,7 +21,7 @@ Address for postal items: `1-1-1 Hitotsubashi, Chiyoda-ku, Tokyo 100-0003, withi
 ### Tokyo Local Students’ Committee (TLSC)
 
 For information on the activities of the Tokyo Local Students' Committee (TLSC), please visit the IAESTE TLSC (Tokyo Local Students' Committee) website.
-- https://www.iaestetlsc.tokyo.jp/
+- https://tlsc.iaeste.or.jp/
 
 ### IAESTE Ombudsperson
 

--- a/hugo/content/ja/contact.md
+++ b/hugo/content/ja/contact.md
@@ -22,7 +22,7 @@ featured_image: ""
 ### 関東地区学生委員会 (TLSC = Tokyo Local Students’ Committee)
 
 関東地区学生委員の活動については、 IAESTE TLSC (Tokyo Local Students’ Committee) の web サイトをご参照ください。
-- https://www.iaestetlsc.tokyo.jp/
+- https://tlsc.iaeste.or.jp/
 
 ### IAESTE オンブズパーソン
 

--- a/hugo/content/ja/join.md
+++ b/hugo/content/ja/join.md
@@ -69,7 +69,7 @@ IAESTE は、学生委員の活動によって支えられています。学部�
 現在、主に関東地区学生委員会 (TLSC = Tokyo Local Students' Committee) がこれらの活動を行っています。
 
 TLSC の活動詳細はこちらをご覧ください。
-- https://www.iaestetlsc.tokyo.jp/
+- https://tlsc.iaeste.or.jp/
 
 ### ボランティア
 

--- a/hugo/content/ja/public-information.md
+++ b/hugo/content/ja/public-information.md
@@ -7,9 +7,9 @@ featured_image: ""
 
 ## 公式メディア
 
-| Item                | Value                                   |
+| Item                 | Value                                   |
 | -------------------- | --------------------------------------- |
-| Domain Name          | `iaeste.or.jp`, `iaestetlsc.tokyo.jp`   |
+| Domain Name          | `iaeste.or.jp`                          |
 | X (Formerly Twitter) | https://x.com/IAESTEJP_TOKYO            |
 | Instagram            | https://www.instagram.com/iaeste_japan/ |
 | Facebook             | https://www.facebook.com/iaeste.japan/  |


### PR DESCRIPTION
TLSCが使用するドメイン名を `iaestetlsc.tokyo.jp` から `tlsc.iaeste.or.jp` に更新する