### PR TITLE
Update cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -47,7 +47,7 @@ steps:
         /tmp/firebase --project ${PROJECT_ID} --non-interactive deploy --only hosting -m "Build ${BUILD_ID}"
       else
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:delete $_CHANNEL_ID --force
-        sleep 10
+        echo "Finish Deleting a Channel"
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:create $_CHANNEL_ID
         /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL $_CHANNEL_URL/ --buildFuture
         cd /workspace/

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -47,6 +47,7 @@ steps:
         /tmp/firebase --project ${PROJECT_ID} --non-interactive deploy --only hosting -m "Build ${BUILD_ID}"
       else
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:delete $_CHANNEL_ID --force
+        sleep 10
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:create $_CHANNEL_ID
         /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL $_CHANNEL_URL/ --buildFuture
         cd /workspace/

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -47,7 +47,7 @@ steps:
         /tmp/firebase --project ${PROJECT_ID} --non-interactive deploy --only hosting -m "Build ${BUILD_ID}"
       else
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:delete $_CHANNEL_ID --force
-        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:create $_CHANNEL_ID --debug
+        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:create $_CHANNEL_ID
         /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL $_CHANNEL_URL/ --buildFuture
         cd /workspace/
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy $_CHANNEL_ID --expires $_EXPIRE_TIME

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -46,8 +46,8 @@ steps:
         cd /workspace/
         /tmp/firebase --project ${PROJECT_ID} --non-interactive deploy --only hosting -m "Build ${BUILD_ID}"
       else
-        /tmp/firebase --project ${PROJECT_ID} hosting:channel:delete $_CHANNEL_ID --force --no-authorized-domains
-        /tmp/firebase --project ${PROJECT_ID} hosting:channel:create $_CHANNEL_ID --no-authorized-domains
+        /tmp/firebase --project ${PROJECT_ID} hosting:channel:delete $_CHANNEL_ID
+        /tmp/firebase --project ${PROJECT_ID} hosting:channel:create $_CHANNEL_ID
         /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL $_CHANNEL_URL/ --buildFuture
         cd /workspace/
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy $_CHANNEL_ID --expires $_EXPIRE_TIME --no-authorized-domains

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -47,7 +47,7 @@ steps:
         /tmp/firebase --project ${PROJECT_ID} --non-interactive deploy --only hosting -m "Build ${BUILD_ID}"
       else
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:delete $_CHANNEL_ID --force
-        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:create $_CHANNEL_ID
+        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:create $_CHANNEL_ID --debug
         /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL $_CHANNEL_URL/ --buildFuture
         cd /workspace/
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy $_CHANNEL_ID --expires $_EXPIRE_TIME

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -47,10 +47,10 @@ steps:
         /tmp/firebase --project ${PROJECT_ID} --non-interactive deploy --only hosting -m "Build ${BUILD_ID}"
       else
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:delete $_CHANNEL_ID --force
-        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:create $_CHANNEL_ID --debug
+        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:create $_CHANNEL_ID
         /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL $_CHANNEL_URL/ --buildFuture
         cd /workspace/
-        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy $_CHANNEL_ID --expires $_EXPIRE_TIME --no-authorized-domains
+        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy $_CHANNEL_ID --expires $_EXPIRE_TIME
       fi
 substitutions:
   _HUGO_VERSION: 0.124.1

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -47,8 +47,7 @@ steps:
         /tmp/firebase --project ${PROJECT_ID} --non-interactive deploy --only hosting -m "Build ${BUILD_ID}"
       else
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:delete $_CHANNEL_ID --force
-        echo "Finish Deleting a Channel"
-        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:create $_CHANNEL_ID
+        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:create $_CHANNEL_ID --debug
         /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL $_CHANNEL_URL/ --buildFuture
         cd /workspace/
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy $_CHANNEL_ID --expires $_EXPIRE_TIME --no-authorized-domains

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -54,3 +54,5 @@ steps:
       fi
 substitutions:
   _HUGO_VERSION: 0.124.1
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -46,8 +46,8 @@ steps:
         cd /workspace/
         /tmp/firebase --project ${PROJECT_ID} --non-interactive deploy --only hosting -m "Build ${BUILD_ID}"
       else
-        /tmp/firebase --project ${PROJECT_ID} hosting:channel:delete $_CHANNEL_ID
-        /tmp/firebase --project ${PROJECT_ID} hosting:channel:create $_CHANNEL_ID
+        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:delete $_CHANNEL_ID --force
+        /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:create $_CHANNEL_ID
         /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL $_CHANNEL_URL/ --buildFuture
         cd /workspace/
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:deploy $_CHANNEL_ID --expires $_EXPIRE_TIME --no-authorized-domains


### PR DESCRIPTION
- firebase hosting の channel 削除、作成のために指定する引数を修正
- [Cloud Build サービス アカウントの変更](https://cloud.google.com/build/docs/cloud-build-service-account-updates) に対応するため `logging: CLOUD_LOGGING_ONLY` を追加