### PR TITLE
Update menbers.md 会員情報の更新

### DIFF
--- a/hugo/content/ja/members.md
+++ b/hugo/content/ja/members.md
@@ -17,11 +17,11 @@ featured_image: ""
 
 ### 大学会員
 
-[大阪大学](https://www.osaka-u.ac.jp/ja/)、[岡山大学](https://www.okayama-u.ac.jp/)、[九州大学](https://www.kyushu-u.ac.jp/ja/)、[京都大学](https://www.kyoto-u.ac.jp/ja)、[慶応義塾大学](https://www.keio.ac.jp/ja/)、[東京大学](https://www.u-tokyo.ac.jp/ja/)、[東京工業大学](https://www.titech.ac.jp/)、[東京都市大学](https://www.tcu.ac.jp/)、[東京都立大学](https://www.tmu.ac.jp/)、[東京農工大学](https://www.tuat.ac.jp/)、[東京理科大学](https://www.tus.ac.jp/)、[同志社大学](https://www.doshisha.ac.jp/)、[東北大学](https://www.tohoku.ac.jp/japanese/)、[室蘭工業大学](https://muroran-it.ac.jp/)、[横浜国立大学](https://www.ynu.ac.jp/)、[立命館大学](https://www.ritsumei.ac.jp/)、[早稲田大学](https://www.waseda.jp/top/)
+[大阪大学](https://www.osaka-u.ac.jp/ja/)、[岡山大学](https://www.okayama-u.ac.jp/)、[京都大学](https://www.kyoto-u.ac.jp/ja)、[慶応義塾大学](https://www.keio.ac.jp/ja/)、[東京大学](https://www.u-tokyo.ac.jp/ja/)、[東京工業大学](https://www.titech.ac.jp/)、[東京都市大学](https://www.tcu.ac.jp/)、[東京都立大学](https://www.tmu.ac.jp/)、[東京農工大学](https://www.tuat.ac.jp/)、[東京理科大学](https://www.tus.ac.jp/)、[同志社大学](https://www.doshisha.ac.jp/)、[東北大学](https://www.tohoku.ac.jp/japanese/)、[豊田工業大学](https://www.toyota-ti.ac.jp/)、[室蘭工業大学](https://muroran-it.ac.jp/)、[横浜国立大学](https://www.ynu.ac.jp/)、[立命館大学](https://www.ritsumei.ac.jp/)、[早稲田大学](https://www.waseda.jp/top/)
 
 ### 個人会員
 
-107 名
+98 名
 
 ## 事業協力会員
 
@@ -41,7 +41,7 @@ featured_image: ""
 
 |   |   |   |
 |---|---|---|
-|[株式会社アルメックVPI](https://www.almec.co.jp/)|[株式会社NTTデータウェーブ](https://www.nttd-wave.com/)|[株式会社KDDI総合研究所](https://www.kddi-research.jp/)|
+|[株式会社アルメックVPI](https://www.almec.co.jp/)|[株式会社KDDI総合研究所](https://www.kddi-research.jp/)|
 |[株式会社寺岡精工](https://www.haseman.co.jp/)|[株式会社長谷萬](https://www.teraokaseiko.com/jp/)|本田 大作|
 
 ## 名誉会員

--- a/hugo/content/ja/members.md
+++ b/hugo/content/ja/members.md
@@ -6,7 +6,7 @@ featured_image: ""
 ---
 
 <div align="right">
-  令和5年 (2023年) 5月28日現在
+  令和6年 (2024年) 4月25日現在
 </div>
 
 ## 正会員 (大学会員及び個人会員)
@@ -17,7 +17,7 @@ featured_image: ""
 
 ### 大学会員
 
-[大阪大学](https://www.osaka-u.ac.jp/ja/)、[岡山大学](https://www.okayama-u.ac.jp/)、[京都大学](https://www.kyoto-u.ac.jp/ja)、[慶応義塾大学](https://www.keio.ac.jp/ja/)、[東京大学](https://www.u-tokyo.ac.jp/ja/)、[東京工業大学](https://www.titech.ac.jp/)、[東京都市大学](https://www.tcu.ac.jp/)、[東京都立大学](https://www.tmu.ac.jp/)、[東京農工大学](https://www.tuat.ac.jp/)、[東京理科大学](https://www.tus.ac.jp/)、[同志社大学](https://www.doshisha.ac.jp/)、[東北大学](https://www.tohoku.ac.jp/japanese/)、[豊田工業大学](https://www.toyota-ti.ac.jp/)、[室蘭工業大学](https://muroran-it.ac.jp/)、[横浜国立大学](https://www.ynu.ac.jp/)、[立命館大学](https://www.ritsumei.ac.jp/)、[早稲田大学](https://www.waseda.jp/top/)
+[大阪大学](https://www.osaka-u.ac.jp/ja/)、[岡山大学](https://www.okayama-u.ac.jp/)、[京都大学](https://www.kyoto-u.ac.jp/ja)、[慶応義塾大学](https://www.keio.ac.jp/ja/)、[東京大学](https://www.u-tokyo.ac.jp/ja/)、[東京工業大学](https://www.titech.ac.jp/)、[東京都市大学](https://www.tcu.ac.jp/)、[東京都立大学](https://www.tmu.ac.jp/)、[東京農工大学](https://www.tuat.ac.jp/)、[東京理科大学](https://www.tus.ac.jp/)、[同志社大学](https://www.doshisha.ac.jp/)、[東北大学](https://www.tohoku.ac.jp/japanese/)、[室蘭工業大学](https://muroran-it.ac.jp/)、[横浜国立大学](https://www.ynu.ac.jp/)、[立命館大学](https://www.ritsumei.ac.jp/)、[早稲田大学](https://www.waseda.jp/top/)
 
 ### 個人会員
 
@@ -34,15 +34,16 @@ featured_image: ""
 |[九州大学](https://www.kyushu-u.ac.jp/ja/)|[株式会社KDDI総合研究所](https://www.kddi-research.jp/)|[一般財団法人軽量計画研究所](https://www.ibs.or.jp/)|
 |[株式会社ソニーコンピュータサイエンス研究所](https://www.sonycsl.co.jp/)|[東急電鉄株式会社](https://www.tokyu.co.jp/railway/)|[東京大学](https://www.u-tokyo.ac.jp/ja/)|
 |[東京都立大学](https://www.tmu.ac.jp/)|[東京理科大学](https://www.tus.ac.jp/)|[東北大学](https://www.tohoku.ac.jp/japanese/)|
-|[株式会社日立製作所](https://www.hitachi.co.jp/)|[プレティア・テクノロジーズ株式会社](https://corporate.pretiaar.com/)|[横浜国立大学](https://www.ynu.ac.jp/)|
+|[豊田工業大学](https://www.toyota-ti.ac.jp/)|[株式会社日立製作所](https://www.hitachi.co.jp/)|[プレティア・テクノロジーズ株式会社](https://corporate.pretiaar.com/)|
+|[株式会社メルカリ](https://about.mercari.com/)|[横浜国立大学](https://www.ynu.ac.jp/)||
 
 ## 賛助会員
 賛助会員には、当協会の運営資金のご支援をいただいています。
 
 |   |   |   |
 |---|---|---|
-|[株式会社アルメックVPI](https://www.almec.co.jp/)|[株式会社KDDI総合研究所](https://www.kddi-research.jp/)|
-|[株式会社寺岡精工](https://www.haseman.co.jp/)|[株式会社長谷萬](https://www.teraokaseiko.com/jp/)|本田 大作|
+|[株式会社アルメックVPI](https://www.almec.co.jp/)|[株式会社KDDI総合研究所](https://www.kddi-research.jp/)|[株式会社寺岡精工](https://www.haseman.co.jp/)|
+|[株式会社長谷萬](https://www.teraokaseiko.com/jp/)|本田 大作||
 
 ## 名誉会員
 


### PR DESCRIPTION
menbers.md内で以下の更新を行いました。
1. 大学会員から九州大学を削除し、豊田工業大学を追加しました。
2. 個人会員数を107名から98名に変更しました。
3. 賛助会員から株式会社NTTデータウェブを削除しました。
確認と修正をよろしくお願いします。