### PR TITLE
強調表示のショートコードを追加

### DIFF
--- a/hugo/assets/ananke/css/custom.css
+++ b/hugo/assets/ananke/css/custom.css
@@ -74,3 +74,75 @@ table tr th:empty {
     flex-direction: column;
     align-items: center;
 }
+
+/* Alert　Tag */
+.alert {
+  position: relative;
+  text-align: left;
+  padding: 10px 15px;
+  min-height: 30px;
+  margin: 1.5em 0;
+  border: none;
+  border-left: 3px solid;
+  word-break: break-word;
+}
+
+.alert div:first-child {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 15px;
+}
+
+.alert-title {
+  text-align: left;
+}
+
+.alert p {
+  margin: 0 0 0;
+}
+
+.alert.note {
+  border-color: #0969da;
+  background-color: var(--background-secondary);
+}
+
+.alert.note .alert-title {
+  color: #0969da;
+}
+
+.alert.important {
+  border-color: #8250df;
+  background-color: var(--background-secondary);
+}
+
+.alert.important .alert-title {
+  color: #8250df;
+}
+
+.alert.warning {
+  border-color: #bf8700;
+  background-color: var(--background-secondary);
+}
+
+.alert.warning .alert-title {
+  color: #bf8700;
+}
+
+.alert.tip {
+  border-color: #1a7f37;
+  background-color: var(--background-secondary);
+}
+
+.alert.tip .alert-title {
+  color: #1a7f37;
+}
+
+.alert.caution {
+  border-color: #cf222e;
+  background-color: var(--background-secondary);
+}
+
+.alert.caution .alert-title {
+  color: #cf222e;
+}

--- a/hugo/layouts/shortcodes/alert.html
+++ b/hugo/layouts/shortcodes/alert.html
@@ -1,0 +1,14 @@
+{{- $type := .Get "type" | default "info" -}}
+{{- if ne $type "note" "tip" "important" "warning" "caution" -}}
+  {{- errorf "unknown type of alert %s" $type -}}
+{{- end -}}
+<div class="alert {{ $type }}">
+  <div>
+    <div>
+      {{ if .Get "title" }}
+        <p class="alert-title">{{ .Get "title" }}</p>
+      {{ end }}
+      {{ .Inner | markdownify }}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## これは何?

GitHub のコンテンツの重要度を示す独特の色とアイコンが表示する機能を真似たショートコード
https://docs.github.com/ja/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts

## 使い方

Markdownファイル内で以下のショートコードを呼び出す。

```
{{< alert type="note" title="Note" >}}
Highlights information that users should take into account, even when skimming.
{{< /alert >}}

{{< alert type="tip" title="Tip" >}}
Optional information to help a user be more successful.
{{< /alert >}}

{{< alert type="important" title="Important" >}}
Crucial information necessary for users to succeed.
{{< /alert >}}

{{< alert type="warning" title="Warning" >}}
Critical content demanding immediate user attention due to potential risks.
{{< /alert >}}

{{< alert type="caution" title="Caution" >}}
Negative potential consequences of an action.
{{< /alert >}}
```

ビルドすると以下の表示になる。

<img width="776" alt="image" src="https://github.com/iaeste-japan/www/assets/114415867/21d03a25-ded3-4a2c-add4-e896d3b77b14">