### PR TITLE
Update go.mod

### DIFF
--- a/hugo/go.mod
+++ b/hugo/go.mod
@@ -1,5 +1,5 @@
 module github.com/iaeste-japan/www
 
-go 1.22
+go 1.23
 
-require github.com/theNewDynamic/gohugo-theme-ananke // indirect
+require github.com/theNewDynamic/gohugo-theme-ananke master // indirect

--- a/hugo/go.mod
+++ b/hugo/go.mod
@@ -2,4 +2,4 @@ module github.com/iaeste-japan/www
 
 go 1.22
 
-require github.com/theNewDynamic/gohugo-theme-ananke v0.0.0-20240503174335-33fbda0e9d3e // indirect
+require github.com/theNewDynamic/gohugo-theme-ananke // indirect


### PR DESCRIPTION
- 要求する go のバージョンを 1.23 に変更
- `github.com/theNewDynamic/gohugo-theme-ananke` のバージョンを指定せず、 `master` ブランチを参照するように指定