### PR TITLE
Update go.mod

### DIFF
--- a/hugo/go.mod
+++ b/hugo/go.mod
@@ -2,4 +2,4 @@ module github.com/iaeste-japan/www
 
 go 1.23
 
-require github.com/theNewDynamic/gohugo-theme-ananke master // indirect
+require github.com/theNewDynamic/gohugo-theme-ananke latest // indirect


### PR DESCRIPTION
`github.com/theNewDynamic/gohugo-theme-ananke` の `latest` を利用するように変更

参考: [git - How to point Go module dependency in go.mod to a latest commit in a repo? - Stack Overflow](https://stackoverflow.com/questions/53682247/how-to-point-go-module-dependency-in-go-mod-to-a-latest-commit-in-a-repo)

> Also if you put the word latest in place of the tag in the go.mod file it will get changed to the latest tag the modules.
> 
> For example:
> ```
> module /my/module
> 
> require (
> ...
> github.com/someone/some_module latest
> ...
> )
> ```