### PR TITLE
Revert "Update cloudbuild.yaml"

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -57,7 +57,7 @@ steps:
       else
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:delete ${_CHANNEL_ID} --force
         /tmp/firebase --project ${PROJECT_ID} --non-interactive hosting:channel:create ${_CHANNEL_ID}
-        /tmp/hugo --cleanDestinationDir --gc --minify --environment development --buildFuture
+        /tmp/hugo --cleanDestinationDir --gc --minify --environment development --baseURL ${_CHANNEL_URL}/ --buildFuture
 
         # Clean up theme-ananke sample
         rm /workspace/public/images/gohugo-default-sample-hero-image.jpg


### PR DESCRIPTION
Reverts iaeste-japan/www#365

Content Security Policy に違反しているため戻す
```
Refused to load the image 'https://www.iaeste.or.jp/images/eyecatch.jpg' because it violates the following Content Security Policy directive: "img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com".
```