### PR TITLE
Revert "bump github.com/theNewDynamic/gohugo-theme-ananke from 2.11.2 to 2.12.0"

### DIFF
--- a/hugo/go.mod
+++ b/hugo/go.mod
@@ -2,4 +2,4 @@ module github.com/iaeste-japan/www
 
 go 1.23
 
-require github.com/theNewDynamic/gohugo-theme-ananke/v2 v2.12.0 // indirect
+require github.com/theNewDynamic/gohugo-theme-ananke/v2 v2.11.2 // indirect

--- a/hugo/go.sum
+++ b/hugo/go.sum
@@ -1,2 +1,2 @@
-github.com/theNewDynamic/gohugo-theme-ananke/v2 v2.12.0 h1:AF1mLNANYQYC9QaFnXh9iZagUj32ImnZIxREP8XeAS0=
-github.com/theNewDynamic/gohugo-theme-ananke/v2 v2.12.0/go.mod h1:+a6uqEsCq0+rqHWY5W5QA3P9DNnxcbyCw+CVEB+Uveg=
+github.com/theNewDynamic/gohugo-theme-ananke/v2 v2.11.2 h1:e57wIClfYebSg7lqJ6ZBbsPaOO+qYEUuqzKbOCwSMqA=
+github.com/theNewDynamic/gohugo-theme-ananke/v2 v2.11.2/go.mod h1:PiXJyylwvAMIfDiHY0SlP8fDwGHhq3ocwbP4TiuAevo=


### PR DESCRIPTION
Reverts iaeste-japan/www#383
---
`2.12.0` に不具合があるので `2.11.2` に戻す

## 不具合 1

### 2.12.0
<img width="1253" alt="image" src="https://github.com/user-attachments/assets/863c62e4-6723-40c0-af0d-99c07a65e6e6" />

### 2.11.2
<img width="1186" alt="image" src="https://github.com/user-attachments/assets/bdb077e2-66d1-46b3-be98-171dbc7aa0e5" />

---
## 不具合 2

### 2.12.0
<img width="1305" alt="image" src="https://github.com/user-attachments/assets/7d13c44d-2d07-4e62-a92b-cf75f75c1a9b" />

### 2.11.2
<img width="1257" alt="image" src="https://github.com/user-attachments/assets/ab7f10e0-4c34-411a-be8a-c4f2fa063d7a" />
