### PR TITLE
Enable Japanese display of alerts for Markdown notation (fixed)

### DIFF
--- a/hugo/i18n/en.toml
+++ b/hugo/i18n/en.toml
@@ -1,0 +1,14 @@
+[important]
+other = "Important"
+
+[note]
+other = "Note"
+
+[tip]
+other = "Tip"
+
+[warning]
+other = "Warning"
+
+[caution]
+other = "Caution"

--- a/hugo/i18n/ja.toml
+++ b/hugo/i18n/ja.toml
@@ -1,0 +1,14 @@
+[important]
+other = "重要"
+
+[note]
+other = "補足情報"
+
+[tip]
+other = "ヒント"
+
+[warning]
+other = "警告"
+
+[caution]
+other = "注意"


### PR DESCRIPTION
#339 ではできなかった日本語表記を可能にする

今回追加する `/hugo/i18n/en.toml`, `/hugo/i18n/ja.toml` は hugo mod で読み込む [github.com/theNewDynamic/gohugo-theme-ananke/blob/main/i18n/ja.toml](https://github.com/theNewDynamic/gohugo-theme-ananke/blob/main/i18n/en.toml), [github.com/theNewDynamic/gohugo-theme-ananke/blob/main/i18n/ja.toml](https://github.com/theNewDynamic/gohugo-theme-ananke/blob/main/i18n/ja.toml) を拡張する

